### PR TITLE
Update systemd files for multi-environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,34 @@ The script will display a usage message and you can then bootstrap your server:
 
 Once you're done head over to the [Piku documentation](https://github.com/piku/piku/#using-piku) to see how to deploy your first app.
 
+### Multi-Environment Setup
+
+You can run multiple piku environments on the same server (e.g., production, staging, dev). Use the `PIKU_USER` environment variable to specify the username for each environment:
+
+```shell
+# Install default piku environment
+./piku-bootstrap install
+
+# Install staging environment
+PIKU_USER=piku-staging ./piku-bootstrap install
+
+# Install dev environment
+PIKU_USER=piku-dev ./piku-bootstrap install
+```
+
+Each environment runs its own uWSGI emperor and nginx path watcher. Apps in different environments can have the same name without conflict.
+
+**Deploying to different environments:**
+
+```shell
+# From your development machine
+git remote add production piku@yourserver:myapp
+git remote add staging piku-staging@yourserver:myapp
+
+git push staging feature-branch
+git push production main
+```
+
 ### Installing other dependencies
 
 `piku-bootstrap` uses Ansible internally and it comes with some extra built-in playbooks which you can use to bootstrap common components onto your `piku` server.

--- a/playbooks/piku.yml
+++ b/playbooks/piku.yml
@@ -76,8 +76,8 @@
 
     - name: Install uwsgi-piku systemd script
       get_url:
-        url: https://raw.githubusercontent.com/piku/piku/master/uwsgi-piku.service
-        dest: /etc/systemd/system/uwsgi-piku.service
+        url: https://raw.githubusercontent.com/piku/piku/master/uwsgi-piku@.service
+        dest: /etc/systemd/system/uwsgi-piku@.service
         mode: 0600
 
     - name: Create piku ansible tmp dir
@@ -168,7 +168,7 @@
 
     - name: Enable uwsgi-piku service
       systemd:
-        name: uwsgi-piku
+        name: uwsgi-piku@{{ user }}
         enabled: yes
         state: started
         masked: no
@@ -178,7 +178,7 @@
     # https://github.com/ansible/ansible/issues/72451
     - name: Actually enable uwsgi-piku service (bug workaround)
       shell:
-        cmd: "systemctl enable uwsgi-piku.service"
+        cmd: "systemctl enable uwsgi-piku@{{ user }}.service"
       when: '"systemctl" in systemctl.stdout and uwsgi_systemd.status.UnitFileState == "enabled-runtime"'
 
     - name: Start uwsgi init script
@@ -201,9 +201,9 @@
         state: restarted
       when: nginx_config_installed is changed
 
-    - name: Get systemd.path piku-nginx.path
+    - name: Get systemd.path piku-nginx@.path
       get_url:
-        url: https://raw.githubusercontent.com/piku/piku/master/piku-nginx.path
+        url: https://raw.githubusercontent.com/piku/piku/master/piku-nginx@.path
         dest: /etc/systemd/system/
       register: piku_nginx_path_installed
 
@@ -213,9 +213,9 @@
         dest: /etc/systemd/system/
       register: piku_nginx_service_installed
 
-    - name: Start piku-nginx.path
+    - name: Start piku-nginx@.path
       systemd:
-        name: piku-nginx.path
+        name: piku-nginx@{{ user }}.path
         state: started
         enabled: yes
       when: ( piku_nginx_service_installed is changed ) and ( "systemctl" in systemctl.stdout )


### PR DESCRIPTION
## Summary

Update playbook to use the new systemd template unit files that support multiple piku environments on the same server.

**Changes:**
- `uwsgi-piku.service` → `uwsgi-piku@.service`
- `piku-nginx.path` → `piku-nginx@.path`
- Enable services with user instance: `uwsgi-piku@{{ user }}`

## Dependencies

This PR depends on piku/piku#419 being merged first (the main piku repo changes that rename the systemd files).